### PR TITLE
Move repository from @ccremer to @nxt-engineering

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Question
-    url: https://github.com/ccremer/kubernetes-client-browser/discussions
+    url: https://github.com/nxt-engineering/kubernetes-client-browser/discussions
     about: Ask or discuss with us, we're happy to help 🙋

--- a/.github/workflows/e2e.mk
+++ b/.github/workflows/e2e.mk
@@ -42,7 +42,7 @@ e2e: run-playwright
 
 .PHONY: run-playwright
 run-playwright: setup-serviceaccount $(example_dir)/.env
-	npx lerna run --scope=@ccremer/$(example) e2e
+	npx lerna run --scope=@nxt-engineering/$(example) e2e
 
 .PHONY: setup-serviceaccount
 setup-serviceaccount: export KUBECONFIG=$(kubeconfig)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - nxt-move
 
 jobs:
   release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ccremer/kubernetes-client",
+  "name": "@nxt-engineering/kubernetes-client",
   "version": "latest",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ccremer/kubernetes-client",
+      "name": "@nxt-engineering/kubernetes-client",
       "version": "latest",
       "workspaces": [
         "packages/*"
@@ -2431,22 +2431,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@ccremer/kubernetes-client": {
-      "resolved": "packages/kubernetes-client",
-      "link": true
-    },
-    "node_modules/@ccremer/kubernetes-client-angular": {
-      "resolved": "packages/kubernetes-client-angular",
-      "link": true
-    },
-    "node_modules/@ccremer/kubernetes-client-example-fetch": {
-      "resolved": "packages/kubernetes-client-example-fetch",
-      "link": true
-    },
-    "node_modules/@ccremer/kubernetes-client-fetch": {
-      "resolved": "packages/kubernetes-client-fetch",
-      "link": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -6141,6 +6125,22 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nxt-engineering/kubernetes-client": {
+      "resolved": "packages/kubernetes-client",
+      "link": true
+    },
+    "node_modules/@nxt-engineering/kubernetes-client-angular": {
+      "resolved": "packages/kubernetes-client-angular",
+      "link": true
+    },
+    "node_modules/@nxt-engineering/kubernetes-client-example-fetch": {
+      "resolved": "packages/kubernetes-client-example-fetch",
+      "link": true
+    },
+    "node_modules/@nxt-engineering/kubernetes-client-fetch": {
+      "resolved": "packages/kubernetes-client-fetch",
+      "link": true
     },
     "node_modules/@octokit/auth-token": {
       "version": "2.5.0",
@@ -21432,7 +21432,7 @@
       }
     },
     "packages/kubernetes-client": {
-      "name": "@ccremer/kubernetes-client",
+      "name": "@nxt-engineering/kubernetes-client",
       "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -21441,7 +21441,7 @@
       }
     },
     "packages/kubernetes-client-angular": {
-      "name": "@ccremer/kubernetes-client-angular",
+      "name": "@nxt-engineering/kubernetes-client-angular",
       "version": "0.7.0",
       "dependencies": {
         "@angular/animations": "^16.0.2",
@@ -21477,7 +21477,7 @@
         "ng-packagr": "^16.0.1"
       },
       "peerDependencies": {
-        "@ccremer/kubernetes-client": "*"
+        "@nxt-engineering/kubernetes-client": "*"
       }
     },
     "packages/kubernetes-client-angular/node_modules/@angular-devkit/architect": {
@@ -22689,7 +22689,7 @@
       }
     },
     "packages/kubernetes-client-example-fetch": {
-      "name": "@ccremer/kubernetes-client-example-fetch",
+      "name": "@nxt-engineering/kubernetes-client-example-fetch",
       "dependencies": {
         "bootstrap": "5.2.3"
       },
@@ -22704,12 +22704,12 @@
         "vite-tsconfig-paths": "4.2.0"
       },
       "peerDependencies": {
-        "@ccremer/kubernetes-client": "*",
-        "@ccremer/kubernetes-client-fetch": "*"
+        "@nxt-engineering/kubernetes-client": "*",
+        "@nxt-engineering/kubernetes-client-fetch": "*"
       }
     },
     "packages/kubernetes-client-fetch": {
-      "name": "@ccremer/kubernetes-client-fetch",
+      "name": "@nxt-engineering/kubernetes-client-fetch",
       "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -22717,7 +22717,7 @@
         "vitest": "0.30.1"
       },
       "peerDependencies": {
-        "@ccremer/kubernetes-client": "*"
+        "@nxt-engineering/kubernetes-client": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ccremer/kubernetes-client",
+  "name": "@nxt-engineering/kubernetes-client",
   "version": "latest",
   "scripts": {
     "build": "lerna run build",
@@ -21,8 +21,8 @@
   ],
   "private": true,
   "type": "module",
-  "repository": "ccremer/kubernetes-client-browser",
-  "author": "ccremer <github.account@chrigel.net>",
+  "repository": "nxt-engineering/kubernetes-client-browser",
+  "author": "nxt-engineering <admin@nxt.engineering>",
   "auto": {
     "plugins": [
       [

--- a/packages/kubernetes-client-angular/package.json
+++ b/packages/kubernetes-client-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ccremer/kubernetes-client-angular",
+  "name": "@nxt-engineering/kubernetes-client-angular",
   "version": "0.7.0",
   "scripts": {
     "ng": "ng",
@@ -38,7 +38,7 @@
     "zone.js": "~0.13.0"
   },
   "peerDependencies": {
-    "@ccremer/kubernetes-client": "*"
+    "@nxt-engineering/kubernetes-client": "*"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "16.0.1",

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md
@@ -32,7 +32,7 @@ Although, the `KubernetesClientService` can be used natively without store suppo
 
 Install the dependencies
 ```bash
-npm install @ccremer/kubernetes-client @ccremer/kubernetes-client-angular
+npm install @nxt-engineering/kubernetes-client @nxt-engineering/kubernetes-client-angular
 ```
 
 Setup the module with `@ngrx/data` in `main.ts`:
@@ -48,7 +48,7 @@ import {
   KubernetesAuthorizerInterceptor,
   KubernetesDataServiceFactory,
   KubernetesDataServiceFactoryConfig,
-} from '@ccremer/kubernetes-client-angular'
+} from '@nxt-engineering/kubernetes-client-angular'
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 
 bootstrapApplication(AppComponent, {
@@ -79,8 +79,8 @@ bootstrapApplication(AppComponent, {
 Optional but highly recommended: Create an extendable Service for each entity, for example in `config-map.service.ts`:
 ```typescript
 import { Injectable } from '@angular/core'
-import { KubernetesCollectionService } from '@ccremer/kubernetes-client-angular'
-import { ConfigMap } from '@ccremer/kubernetes-client/types/core'
+import { KubernetesCollectionService } from '@nxt-engineering/kubernetes-client-angular'
+import { ConfigMap } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 
 @Injectable({
@@ -97,7 +97,7 @@ Configure and consume the service in a component like `app.component.ts`:
 ```typescript
 import { Component, OnInit } from '@angular/core'
 import { ConfigMapService } from './config-map.service'
-import { KubernetesAuthorizerService } from '@ccremer/kubernetes-client-angular'
+import { KubernetesAuthorizerService } from '@nxt-engineering/kubernetes-client-angular'
 
 @Component({
   selector: 'app-root',
@@ -163,7 +163,7 @@ The default built-in client can be extended in various points.
 You can also provide your own resource type, as long as it fulfills the `KubeMeta` interface contract.
 
 ```typescript
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 export interface MyCustomResource extends KubeObject {
   apiVersion: 'customgroup/v1'

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md.njk
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md.njk
@@ -32,7 +32,7 @@ Although, the `KubernetesClientService` can be used natively without store suppo
 
 Install the dependencies
 ```bash
-npm install @ccremer/kubernetes-client @ccremer/kubernetes-client-angular
+npm install @nxt-engineering/kubernetes-client @nxt-engineering/kubernetes-client-angular
 ```
 
 Setup the module with `@ngrx/data` in `main.ts`:

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/app.component.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { ConfigMapService } from './config-map.service'
-import { KubernetesAuthorizerService } from '@ccremer/kubernetes-client-angular'
+import { KubernetesAuthorizerService } from '@nxt-engineering/kubernetes-client-angular'
 
 @Component({
   selector: 'app-root',

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/config-map.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/config-map.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
-import { KubernetesCollectionService } from '@ccremer/kubernetes-client-angular'
-import { ConfigMap } from '@ccremer/kubernetes-client/types/core'
+import { KubernetesCollectionService } from '@nxt-engineering/kubernetes-client-angular'
+import { ConfigMap } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 
 @Injectable({

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/custom-type.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/custom-type.ts
@@ -1,4 +1,4 @@
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 export interface MyCustomResource extends KubeObject {
   apiVersion: 'customgroup/v1'

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/main.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/main.ts
@@ -9,7 +9,7 @@ import {
   KubernetesAuthorizerInterceptor,
   KubernetesDataServiceFactory,
   KubernetesDataServiceFactoryConfig,
-} from '@ccremer/kubernetes-client-angular'
+} from '@nxt-engineering/kubernetes-client-angular'
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 
 bootstrapApplication(AppComponent, {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/tsconfig.json
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@ccremer/kubernetes-client/*": ["../../../../kubernetes-client/dist/*"],
-      "@ccremer/kubernetes-client-angular": ["../../../dist"]
+      "@nxt-engineering/kubernetes-client/*": ["../../../../kubernetes-client/dist/*"],
+      "@nxt-engineering/kubernetes-client-angular": ["../../../dist"]
     }
   }
 }

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
@@ -20,9 +20,8 @@
     "browser"
   ],
   "files": [
-    "esm2020",
-    "fesm2015",
-    "fesm2020",
+    "esm2022",
+    "fesm2022",
     "lib",
     "index.d.ts",
     "public-api.d.ts"

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@ccremer/kubernetes-client-angular",
+  "name": "@nxt-engineering/kubernetes-client-angular",
   "peerDependencies": {
     "@angular/common": "^16.0.0",
     "@angular/core": "^16.0.0",
-    "@ccremer/kubernetes-client": "*"
+    "@nxt-engineering/kubernetes-client": "*"
   },
   "dependencies": {
     "tslib": "2.5.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ccremer/kubernetes-client-browser"
+    "url": "https://github.com/nxt-engineering/kubernetes-client-browser"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/authorization.k8s.io/metadata.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/authorization.k8s.io/metadata.ts
@@ -1,5 +1,8 @@
 import { EntityMetadataMap } from '@ngrx/data'
-import { SelfSubjectAccessReview, SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
+import {
+  SelfSubjectAccessReview,
+  SelfSubjectRulesReview,
+} from '@nxt-engineering/kubernetes-client/types/authorization.k8s.io'
 
 export const AuthorizationEntityMetadataMap: EntityMetadataMap = {
   'authorization.k8s.io/v1/selfsubjectrulesreviews': {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/core/metadata.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/core/metadata.ts
@@ -1,5 +1,5 @@
 import { EntityMetadataMap } from '@ngrx/data'
-import { ConfigMap, Secret } from '@ccremer/kubernetes-client/types/core'
+import { ConfigMap, Secret } from '@nxt-engineering/kubernetes-client/types/core'
 import { toNamespacedName } from './validator'
 
 export const CoreEntityMetadataMap: EntityMetadataMap = {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/core/validator.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/entities/core/validator.ts
@@ -1,4 +1,4 @@
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 /**
  * Returns the namespaced name for the given entity.

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-client.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-client.service.ts
@@ -2,17 +2,17 @@ import { Injectable, Optional } from '@angular/core'
 import { HttpClient } from '@angular/common/http'
 import { KubernetesUrlGeneratorService } from './kubernetes-url-generator.service'
 import { DataServiceConfig } from './config'
-import { KubeObject, Status } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject, Status } from '@nxt-engineering/kubernetes-client/types/core'
 import { map, Observable } from 'rxjs'
-import { toURLSearchParams } from '@ccremer/kubernetes-client/api'
+import { toURLSearchParams } from '@nxt-engineering/kubernetes-client/api'
 import {
   DeleteOptions,
   GetOptions,
   ListOptions,
   MutationOptions,
   PatchOptions,
-} from '@ccremer/kubernetes-client/api/options'
-import { KubeList } from '@ccremer/kubernetes-client/types/core/KubeList'
+} from '@nxt-engineering/kubernetes-client/api/options'
+import { KubeList } from '@nxt-engineering/kubernetes-client/types/core/KubeList'
 
 @Injectable()
 export class KubernetesClientService {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-collection-service-factory.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-collection-service-factory.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 import { KubernetesCollectionService } from './kubernetes-collection.service'
 

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-collection.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-collection.service.ts
@@ -4,7 +4,7 @@ import {
   EntityCollectionServiceElementsFactory,
   QueryParams,
 } from '@ngrx/data'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { filter, map, Observable, of, take, tap } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Optional } from '@angular/core'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionDataService } from '@ngrx/data'
 import { KubernetesDataService } from './kubernetes-data.service'
 import { KubernetesUrlGeneratorService } from './kubernetes-url-generator.service'

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data.service.ts
@@ -1,5 +1,5 @@
 import { EntityCollectionDataService, QueryParams } from '@ngrx/data'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { map, Observable } from 'rxjs'
 import { Update } from '@ngrx/entity'
 import { HttpOptions } from '@ngrx/data/src/dataservices/interfaces'

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-options.util.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-options.util.ts
@@ -6,7 +6,7 @@ import {
   GetOptions,
   ListOptions,
   MutationOptions,
-} from '@ccremer/kubernetes-client/api/options'
+} from '@nxt-engineering/kubernetes-client/api/options'
 import { HttpParams } from '@angular/common/http'
 
 export function commonOptions(httpOptions?: HttpOptions): CommonOptions | undefined {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-url-generator.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-url-generator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Optional } from '@angular/core'
-import { HttpMethods, KubernetesUrlGenerator, UrlGenerator } from '@ccremer/kubernetes-client/api'
+import { HttpMethods, KubernetesUrlGenerator, UrlGenerator } from '@nxt-engineering/kubernetes-client/api'
 import { KubernetesDataServiceFactoryConfig } from './kubernetes-data-service-factory.service'
 
 @Injectable({

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/client/client.component.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/client/client.component.ts
@@ -3,11 +3,11 @@ import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } 
 import { CommonModule, NgFor } from '@angular/common'
 import { SecretService } from '../store/secret.service'
 import { ConfigMapService } from '../store/config-map.service'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { Observable } from 'rxjs'
 import { EntityActionOptions } from '@ngrx/data'
 import { toHttpOptions } from 'kubernetes-client-angular'
-import { ListOptions } from '@ccremer/kubernetes-client/api'
+import { ListOptions } from '@nxt-engineering/kubernetes-client/api'
 
 @Component({
   standalone: true,

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/config-map.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/config-map.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { KubernetesCollectionService } from 'kubernetes-client-angular'
-import { ConfigMap } from '@ccremer/kubernetes-client/types/core'
+import { ConfigMap } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 
 @Injectable({

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/secret.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/secret.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { KubernetesCollectionService } from 'kubernetes-client-angular'
-import { Secret } from '@ccremer/kubernetes-client/types/core'
+import { Secret } from '@nxt-engineering/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 
 @Injectable({

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/self-subject-rules-review.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/self-subject-rules-review.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { KubernetesCollectionService } from 'kubernetes-client-angular'
-import { SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
+import { SelfSubjectRulesReview } from '@nxt-engineering/kubernetes-client/types/authorization.k8s.io'
 import { EntityActionOptions, EntityCollectionServiceElementsFactory } from '@ngrx/data'
 import { map, Observable } from 'rxjs'
 

--- a/packages/kubernetes-client-angular/tsconfig.json
+++ b/packages/kubernetes-client-angular/tsconfig.json
@@ -10,7 +10,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "paths": {
       "kubernetes-client-angular": ["dist"],
-      "@ccremer/kubernetes-client/*": ["../kubernetes-client/dist/*"]
+      "@nxt-engineering/kubernetes-client/*": ["../kubernetes-client/dist/*"]
     },
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/kubernetes-client-example-fetch/package.json
+++ b/packages/kubernetes-client-example-fetch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ccremer/kubernetes-client-example-fetch",
+  "name": "@nxt-engineering/kubernetes-client-example-fetch",
   "private": true,
   "scripts": {
     "format": "prettier --write ./**/*.{js,html,ts,json}",
@@ -26,8 +26,8 @@
     "bootstrap": "5.2.3"
   },
   "peerDependencies": {
-    "@ccremer/kubernetes-client": "*",
-    "@ccremer/kubernetes-client-fetch": "*"
+    "@nxt-engineering/kubernetes-client": "*",
+    "@nxt-engineering/kubernetes-client-fetch": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kubernetes-client-example-fetch/src/js/main.ts
+++ b/packages/kubernetes-client-example-fetch/src/js/main.ts
@@ -2,8 +2,8 @@ import '../styles.scss'
 import { Client, KubeClientBuilder } from '../../../kubernetes-client-fetch/src'
 import { newSelfSubjectRulesReview } from './types'
 import { createAlert } from './alerts'
-import { WatchEvent } from '@ccremer/kubernetes-client-fetch'
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { WatchEvent } from '@nxt-engineering/kubernetes-client-fetch'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 console.debug('Starting up...')
 

--- a/packages/kubernetes-client-example-fetch/src/js/types.ts
+++ b/packages/kubernetes-client-example-fetch/src/js/types.ts
@@ -1,4 +1,4 @@
-import { SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
+import { SelfSubjectRulesReview } from '@nxt-engineering/kubernetes-client/types/authorization.k8s.io'
 
 export function newSelfSubjectRulesReview(namespace: string): SelfSubjectRulesReview {
   return {

--- a/packages/kubernetes-client-example-fetch/tsconfig.json
+++ b/packages/kubernetes-client-example-fetch/tsconfig.json
@@ -4,8 +4,8 @@
     "outDir": "./dist",
     "baseUrl": ".",
     "paths": {
-      "@ccremer/kubernetes-client/*": ["../kubernetes-client/src/*"],
-      "@ccremer/kubernetes-client-fetch": ["../kubernetes-client-fetch/src/"]
+      "@nxt-engineering/kubernetes-client/*": ["../kubernetes-client/src/*"],
+      "@nxt-engineering/kubernetes-client-fetch": ["../kubernetes-client-fetch/src/"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/kubernetes-client-fetch/README.md
+++ b/packages/kubernetes-client-fetch/README.md
@@ -27,13 +27,13 @@ Ideal for SPA-like apps and CRDs.
 
 Install the client
 ```bash
-npm install @ccremer/kubernetes-client @ccremer/kubernetes-client-fetch
+npm install @nxt-engineering/kubernetes-client @nxt-engineering/kubernetes-client-fetch
 ```
 
 Setup the client and make a request
 ```typescript
-import { KubeClientBuilder } from '@ccremer/kubernetes-client-fetch'
-import { SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
+import { KubeClientBuilder } from '@nxt-engineering/kubernetes-client-fetch'
+import { SelfSubjectRulesReview } from '@nxt-engineering/kubernetes-client/types/authorization.k8s.io'
 
 // token:
 // a valid JWT for Kubernetes.
@@ -64,7 +64,7 @@ client
 You can also provide your own resource type, as long as it fulfills the `KubeMeta` interface contract.
 
 ```typescript
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 export interface MyCustomResource extends KubeObject {
   apiVersion: 'customgroup/v1'
@@ -130,7 +130,7 @@ The default built-in client can be extended in various points.
   However, currently only a variant with a JWT token is supported, created with `Config.FromToken()` combined with `DefaultAuthorizer`.
 * There is no validation to the passed in payloads or returned results.
 * Many Kubernetes resource types are missing, and they're not (yet?) generated from the Kubernetes API scheme.
-  Implement your own or better yet, contribute to `@ccremer/kubernetes-client` :)
+  Implement your own or better yet, contribute to `@nxt-engineering/kubernetes-client` :)
 
 ## Production readiness
 

--- a/packages/kubernetes-client-fetch/README.md.njk
+++ b/packages/kubernetes-client-fetch/README.md.njk
@@ -27,7 +27,7 @@ Ideal for SPA-like apps and CRDs.
 
 Install the client
 ```bash
-npm install @ccremer/kubernetes-client @ccremer/kubernetes-client-fetch
+npm install @nxt-engineering/kubernetes-client @nxt-engineering/kubernetes-client-fetch
 ```
 
 Setup the client and make a request
@@ -75,7 +75,7 @@ The default built-in client can be extended in various points.
   However, currently only a variant with a JWT token is supported, created with `Config.FromToken()` combined with `DefaultAuthorizer`.
 * There is no validation to the passed in payloads or returned results.
 * Many Kubernetes resource types are missing, and they're not (yet?) generated from the Kubernetes API scheme.
-  Implement your own or better yet, contribute to `@ccremer/kubernetes-client` :)
+  Implement your own or better yet, contribute to `@nxt-engineering/kubernetes-client` :)
 
 ## Production readiness
 

--- a/packages/kubernetes-client-fetch/examples/custom-type.ts
+++ b/packages/kubernetes-client-fetch/examples/custom-type.ts
@@ -1,4 +1,4 @@
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 
 export interface MyCustomResource extends KubeObject {
   apiVersion: 'customgroup/v1'

--- a/packages/kubernetes-client-fetch/examples/getting-started.ts
+++ b/packages/kubernetes-client-fetch/examples/getting-started.ts
@@ -1,5 +1,5 @@
-import { KubeClientBuilder } from '@ccremer/kubernetes-client-fetch'
-import { SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
+import { KubeClientBuilder } from '@nxt-engineering/kubernetes-client-fetch'
+import { SelfSubjectRulesReview } from '@nxt-engineering/kubernetes-client/types/authorization.k8s.io'
 
 // token:
 // a valid JWT for Kubernetes.

--- a/packages/kubernetes-client-fetch/examples/tsconfig.json
+++ b/packages/kubernetes-client-fetch/examples/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@ccremer/kubernetes-client/*": ["../../kubernetes-client/src/*"],
-      "@ccremer/kubernetes-client-fetch": ["../src/"]
+      "@nxt-engineering/kubernetes-client/*": ["../../kubernetes-client/src/*"],
+      "@nxt-engineering/kubernetes-client-fetch": ["../src/"]
     }
   }
 }

--- a/packages/kubernetes-client-fetch/package.json
+++ b/packages/kubernetes-client-fetch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ccremer/kubernetes-client-fetch",
+  "name": "@nxt-engineering/kubernetes-client-fetch",
   "version": "0.2.0",
   "description": "Generic Kubernetes client run in the Browser",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ccremer/kubernetes-client-browser.git"
+    "url": "git+https://github.com/nxt-engineering/kubernetes-client-browser.git"
   },
   "keywords": [
     "kubernetes",
@@ -23,12 +23,12 @@
     "typescript",
     "fetch"
   ],
-  "author": "ccremer",
+  "author": "nxt-engineering",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ccremer/kubernetes-client-browser/issues"
+    "url": "https://github.com/nxt-engineering/kubernetes-client-browser/issues"
   },
-  "homepage": "https://github.com/ccremer/kubernetes-client-browser#readme",
+  "homepage": "https://github.com/nxt-engineering/kubernetes-client-browser#readme",
   "types": "index.d.ts",
   "type": "module",
   "files": [
@@ -40,7 +40,7 @@
     "vitest": "0.30.1"
   },
   "peerDependencies": {
-    "@ccremer/kubernetes-client": "*"
+    "@nxt-engineering/kubernetes-client": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kubernetes-client-fetch/src/authorizer.ts
+++ b/packages/kubernetes-client-fetch/src/authorizer.ts
@@ -1,4 +1,4 @@
-import { KubeConfig } from '@ccremer/kubernetes-client/api'
+import { KubeConfig } from '@nxt-engineering/kubernetes-client/api'
 
 export interface Authorizer {
   /**

--- a/packages/kubernetes-client-fetch/src/builder.ts
+++ b/packages/kubernetes-client-fetch/src/builder.ts
@@ -1,4 +1,4 @@
-import { Config, KubeConfig, KubernetesUrlGenerator, UrlGenerator } from '@ccremer/kubernetes-client/api'
+import { Config, KubeConfig, KubernetesUrlGenerator, UrlGenerator } from '@nxt-engineering/kubernetes-client/api'
 import { FetchClient, FetchFn } from './fetch-client'
 import { Authorizer, DefaultAuthorizer, NoopAuthorizer } from './authorizer'
 import { Client } from './client'

--- a/packages/kubernetes-client-fetch/src/client.ts
+++ b/packages/kubernetes-client-fetch/src/client.ts
@@ -1,4 +1,4 @@
-import { KubeList, KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeList, KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import {
   DeleteOptions,
   GetOptions,
@@ -6,7 +6,7 @@ import {
   MutationOptions,
   PatchOptions,
   WatchOptions,
-} from '@ccremer/kubernetes-client/api/options'
+} from '@nxt-engineering/kubernetes-client/api/options'
 
 export interface ClientWithGet {
   /**

--- a/packages/kubernetes-client-fetch/src/fetch-client.ts
+++ b/packages/kubernetes-client-fetch/src/fetch-client.ts
@@ -1,4 +1,4 @@
-import { ErrorStatus, KubeList, KubeObject, KubernetesError } from '@ccremer/kubernetes-client/types/core'
+import { ErrorStatus, KubeList, KubeObject, KubernetesError } from '@nxt-engineering/kubernetes-client/types/core'
 import { Authorizer } from './authorizer'
 import {
   ClientOptions,
@@ -11,7 +11,7 @@ import {
   toURLSearchParams,
   UrlGenerator,
   WatchOptions,
-} from '@ccremer/kubernetes-client/api'
+} from '@nxt-engineering/kubernetes-client/api'
 import { JSONLineStream } from './jsonlinestream'
 import { WatchEventStream } from './watcheventstream'
 import { Client, WatchEvent, WatchHandlers, WatchResult } from './client'

--- a/packages/kubernetes-client-fetch/src/watcheventstream.ts
+++ b/packages/kubernetes-client-fetch/src/watcheventstream.ts
@@ -1,4 +1,4 @@
-import { KubeObject } from '@ccremer/kubernetes-client/types/core'
+import { KubeObject } from '@nxt-engineering/kubernetes-client/types/core'
 import { WatchEvent, WatchHandlers } from './client'
 
 export class WatchEventStream<K extends KubeObject> extends WritableStream<WatchEvent<K>> {

--- a/packages/kubernetes-client-fetch/tsconfig.json
+++ b/packages/kubernetes-client-fetch/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
-      "@ccremer/kubernetes-client/*": ["../kubernetes-client/dist/*"]
+      "@nxt-engineering/kubernetes-client/*": ["../kubernetes-client/dist/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/kubernetes-client/README.md
+++ b/packages/kubernetes-client/README.md
@@ -7,6 +7,6 @@ This package is the core of a Kubernetes client made for a frontend.
 
 Checkout the other packages with concrete implementations:
 
-* `@ccremer/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
-* `@ccremer/kubernetes-client-angular`: Made for Angular framework with NGRX state management.
+* `@nxt-engineering/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
+* `@nxt-engineering/kubernetes-client-angular`: Made for Angular framework with NGRX state management.
 

--- a/packages/kubernetes-client/README.md
+++ b/packages/kubernetes-client/README.md
@@ -5,8 +5,8 @@ Ideal for SPA-like apps and CRDs.
 
 This package is the core of a Kubernetes client made for a frontend.
 
-Checkout the other packages with concrete implementations:
+Check out the other packages with concrete implementations:
 
-* `@nxt-engineering/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
-* `@nxt-engineering/kubernetes-client-angular`: Made for Angular framework with NGRX state management.
+* [@nxt-engineering/kubernetes-client-fetch](https://www.npmjs.com/package/@nxt-engineering/kubernetes-client-fetch): Uses the Browser's native Fetch API.
+* [@nxt-engineering/kubernetes-client-angular](https://www.npmjs.com/package/@nxt-engineering/kubernetes-client-angular): Made for Angular framework with NGRX state management.
 

--- a/packages/kubernetes-client/README.md.njk
+++ b/packages/kubernetes-client/README.md.njk
@@ -5,7 +5,7 @@ Ideal for SPA-like apps and CRDs.
 
 This package is the core of a Kubernetes client made for a frontend.
 
-Checkout the other packages with concrete implementations:
+Check out the other packages with concrete implementations:
 
-* `@nxt-engineering/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
-* `@nxt-engineering/kubernetes-client-angular`: Made for Angular framework with NGRX state management.
+* [@nxt-engineering/kubernetes-client-fetch](https://www.npmjs.com/package/@nxt-engineering/kubernetes-client-fetch): Uses the Browser's native Fetch API.
+* [@nxt-engineering/kubernetes-client-angular](https://www.npmjs.com/package/@nxt-engineering/kubernetes-client-angular): Made for Angular framework with NGRX state management.

--- a/packages/kubernetes-client/README.md.njk
+++ b/packages/kubernetes-client/README.md.njk
@@ -7,5 +7,5 @@ This package is the core of a Kubernetes client made for a frontend.
 
 Checkout the other packages with concrete implementations:
 
-* `@ccremer/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
-* `@ccremer/kubernetes-client-angular`: Made for Angular framework with NGRX state management.
+* `@nxt-engineering/kubernetes-client-fetch`: Uses the Browser's native Fetch API.
+* `@nxt-engineering/kubernetes-client-angular`: Made for Angular framework with NGRX state management.

--- a/packages/kubernetes-client/package.json
+++ b/packages/kubernetes-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ccremer/kubernetes-client",
+  "name": "@nxt-engineering/kubernetes-client",
   "version": "0.7.0",
   "description": "Generic Kubernetes client run in the Browser",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ccremer/kubernetes-client-browser.git"
+    "url": "git+https://github.com/nxt-engineering/kubernetes-client-browser.git"
   },
   "keywords": [
     "kubernetes",
@@ -24,12 +24,12 @@
     "typescript",
     "fetch"
   ],
-  "author": "ccremer",
+  "author": "nxt-engineering",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ccremer/kubernetes-client-browser/issues"
+    "url": "https://github.com/nxt-engineering/kubernetes-client-browser/issues"
   },
-  "homepage": "https://github.com/ccremer/kubernetes-client-browser#readme",
+  "homepage": "https://github.com/nxt-engineering/kubernetes-client-browser#readme",
   "types": "index.d.ts",
   "type": "module",
   "files": [


### PR DESCRIPTION
* Transfers ownership of the Repo and all published artifacts from @ccremer to @nxtengineering (change of intellectual property)
* Replaces and republishes all npm packages with a v1 major version bump.

### Checklist for PR Authors

- [x] Link this PR to related issues if applicable
- [x] This PR contains a single logical change (to build a better changelog)
- [x] I have cleaned up the commit history (no useless army of tiny "Update file xyz" commits)
- [x] PR title _doesn't_ contain a categorization prefix like "[chore]" or "feat:" -> There are labels for that

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these items are not required to open a PR and can be done afterwards,
while the PR is open.
-->

### Checklist for PR Reviewers

- [x] Categorize the PR by setting a good title and adding one of the release labels (see below)

  <details>
  <summary>Labels that control the release</summary>

  * `major`: major
  * `minor`: minor
  * `patch`: patch
  * `performance`: patch
  * `skip-release`: none
  * `release`: Release after merge. Use together with a Label that doesn't immediately release, e.g. `internal`.
  * `internal`: none
  * `documentation`: none
  * `tests`: none
  * `dependencies`: none

  </details>

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nxt-engineering/kubernetes-client-angular@1.0.0-canary.1.c5c1b50.0
  npm install @nxt-engineering/kubernetes-client-fetch@1.0.0-canary.1.c5c1b50.0
  npm install @nxt-engineering/kubernetes-client@1.0.0-canary.1.c5c1b50.0
  # or 
  yarn add @nxt-engineering/kubernetes-client-angular@1.0.0-canary.1.c5c1b50.0
  yarn add @nxt-engineering/kubernetes-client-fetch@1.0.0-canary.1.c5c1b50.0
  yarn add @nxt-engineering/kubernetes-client@1.0.0-canary.1.c5c1b50.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
